### PR TITLE
Changed csv_file_name

### DIFF
--- a/sender.rb
+++ b/sender.rb
@@ -9,7 +9,7 @@ CONFIG = YAML.load_file('./secrets/secrets.yml')
 date = Date.today-2
 
 file_date = date.strftime("%Y%m")
-csv_file_name = "#{CONFIG["package_name"]}_#{file_date}.csv"
+csv_file_name = "reviews_#{CONFIG["package_name"]}_#{file_date}.csv"
 
 system "BOTO_PATH=./secrets/.boto gsutil/gsutil cp -r gs://#{CONFIG["app_repo"]}/reviews/#{csv_file_name} ."
 


### PR DESCRIPTION
Hi!
In all our projects csv files with reviews have names starting with 'review_' ([example](http://cl.ly/image/0j3i040D2Q2N)) , so I've changed csv_file_name variable.
